### PR TITLE
Made tests default but optional

### DIFF
--- a/steps/rust-test.yml
+++ b/steps/rust-test.yml
@@ -2,6 +2,9 @@ parameters:
   - name: workingDirectory
     type: string
     default: "./"
+  - name: runTests
+    type: boolean
+    default: true
   - name: runDocTests
     type: boolean
     default: true
@@ -11,9 +14,10 @@ steps:
     parameters:
       workingDirectory: ${{ parameters.workingDirectory }}
 
-  - script: cargo test --verbose -- --nocapture
-    displayName: Run tests
-    workingDirectory: ${{ parameters.workingDirectory }}
+  - ${{ if parameters.runTests }}:
+      - script: cargo test --verbose -- --nocapture
+        displayName: Run tests
+        workingDirectory: ${{ parameters.workingDirectory }}
 
   - ${{ if parameters.runDocTests }}:
       - script: cargo test --verbose --doc -- --no-capture


### PR DESCRIPTION
This enables actors to avoid running `cargo test` with the default flags, as this will always fail.