### PR TITLE
Removes incorrect flag

### DIFF
--- a/steps/rust-test.yml
+++ b/steps/rust-test.yml
@@ -16,6 +16,6 @@ steps:
     workingDirectory: ${{ parameters.workingDirectory }}
 
   - ${{ if parameters.runDocTests }}:
-      - script: cargo test --verbose --doc -- --no-capture
+      - script: cargo test --verbose --doc
         displayName: Run doc tests
         workingDirectory: ${{ parameters.workingDirectory }}


### PR DESCRIPTION
Apparently `--no-capture` is not a valid option for doc tests